### PR TITLE
feat: add slim skin endpoint support

### DIFF
--- a/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core.Interfaces/Integrations/IServicesIntegrationProcedures.cs
+++ b/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core.Interfaces/Integrations/IServicesIntegrationProcedures.cs
@@ -17,8 +17,10 @@ namespace GmlCore.Interfaces.Integrations
         Task SetActiveAuthService(IAuthServiceInfo? service);
         Task<string> GetSkinServiceAsync();
         Task<string> GetCloakServiceAsync();
+        Task<string> GetSlimServiceAsync();
         Task SetSkinServiceAsync(string url);
         Task SetCloakServiceAsync(string url);
+        Task SetSlimServiceAsync(string url);
         Task<string?> GetSentryService();
         Task SetSentryService(string url);
         Task UpdateDiscordRpc(IDiscordRpcClient client);

--- a/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core.Interfaces/Integrations/ITextureProvider.cs
+++ b/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core.Interfaces/Integrations/ITextureProvider.cs
@@ -11,4 +11,5 @@ public interface ITextureProvider
     Task<Stream> GetSkinStream(string? textureUrl);
     Task<Stream> GetCloakStream(string? userTextureSkinUrl);
     Task<Stream> GetHeadByNameStream(string? userName);
+    Task<bool> IsSlim(string url);
 }

--- a/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core/Core/Constants/StorageConstants.cs
+++ b/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core/Core/Constants/StorageConstants.cs
@@ -7,6 +7,7 @@ namespace Gml.Core.Constants
         public const string ActiveAuthService = "ActiveAuthService";
         public const string SkinUrl = "SkinUrl";
         public const string CloakUrl = "CloakUrl";
+        public const string SlimUrl = "SlimUrl";
         public const string SentrySdnUrl = "SentrySdnUrl";
         public const string DiscordRpcClient = "DiscordRpcClient";
         public const string Settings = "Settings";

--- a/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core/Core/Integrations/ServicesIntegrationProcedures.cs
+++ b/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core/Core/Integrations/ServicesIntegrationProcedures.cs
@@ -91,6 +91,12 @@ public class ServicesIntegrationProcedures(
                ?? throw new Exception("Сервис плащей не настроен");
     }
 
+    public async Task<string> GetSlimServiceAsync()
+    {
+        return await storage.GetAsync<string>(StorageConstants.SlimUrl)
+               ?? throw new Exception("Сервис slim не настроен");
+    }
+
     public Task SetSkinServiceAsync(string url)
     {
         return storage.SetAsync(StorageConstants.SkinUrl, url);
@@ -99,6 +105,11 @@ public class ServicesIntegrationProcedures(
     public Task SetCloakServiceAsync(string url)
     {
         return storage.SetAsync(StorageConstants.CloakUrl, url);
+    }
+
+    public Task SetSlimServiceAsync(string url)
+    {
+        return storage.SetAsync(StorageConstants.SlimUrl, url);
     }
 
     public Task<string?> GetSentryService()

--- a/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core/Core/Integrations/TextureProvider.cs
+++ b/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core/Core/Integrations/TextureProvider.cs
@@ -106,4 +106,17 @@ public class TextureProvider(string textureServiceEndpoint, IBugTrackerProcedure
 
         return null;
     }
+
+    public async Task<bool> IsSlim(string url)
+    {
+        try
+        {
+            var response = await _httpClintSkinChecker.GetAsync(url);
+            return response.IsSuccessStatusCode;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core/Core/User/User.cs
+++ b/src/Gml.Web.Api/src/Gml.Core/src/Gml.Core/Core/User/User.cs
@@ -44,6 +44,17 @@ namespace Gml.Core.User
             TextureSkinGuid = !string.IsNullOrEmpty(TextureSkinUrl)
                 ? Guid.NewGuid().ToString()
                 : string.Empty;
+
+            try
+            {
+                var slimService = await Manager.Integrations.GetSlimServiceAsync();
+                var slimUrl = slimService.Replace("{userName}", Name).Replace("{userUuid}", Uuid ?? string.Empty);
+                IsSlim = await Manager.Integrations.TextureProvider.IsSlim(slimUrl);
+            }
+            catch
+            {
+                IsSlim = false;
+            }
         }
 
 

--- a/src/Gml.Web.Api/src/Gml.Web.Api/Core/Extensions/EndpointsExtensions.cs
+++ b/src/Gml.Web.Api/src/Gml.Web.Api/Core/Extensions/EndpointsExtensions.cs
@@ -356,6 +356,29 @@ public static class EndpointsExtensions
             .Produces<ResponseMessage>((int)HttpStatusCode.BadRequest)
             .RequireAuthorization(c => c.RequireRole("Admin"));
 
+        app.MapGet("/api/v1/integrations/texture/slim", TextureIntegrationHandler.GetSlimUrl)
+            .WithOpenApi(generatedOperation =>
+            {
+                generatedOperation.Summary = "Получение ссылки на сервис slim";
+                return generatedOperation;
+            })
+            .WithDescription("Получение ссылки на сервис slim")
+            .WithName("Get slim texture url")
+            .WithTags("Integration/Textures")
+            .Produces<ResponseMessage>((int)HttpStatusCode.BadRequest);
+
+        app.MapPut("/api/v1/integrations/texture/slim", TextureIntegrationHandler.SetSlimUrl)
+            .WithOpenApi(generatedOperation =>
+            {
+                generatedOperation.Summary = "Обновление ссылки на сервис slim";
+                return generatedOperation;
+            })
+            .WithDescription("Обновление ссылки на сервис slim")
+            .WithName("Update slim texture url")
+            .WithTags("Integration/Textures")
+            .Produces<ResponseMessage>((int)HttpStatusCode.BadRequest)
+            .RequireAuthorization(c => c.RequireRole("Admin"));
+
         app.MapPost("/api/v1/integrations/texture/skins/load", TextureIntegrationHandler.UpdateUserSkin)
             .WithOpenApi(generatedOperation =>
             {

--- a/src/Gml.Web.Api/src/Gml.Web.Api/Core/Handlers/ITextureIntegrationHandler.cs
+++ b/src/Gml.Web.Api/src/Gml.Web.Api/Core/Handlers/ITextureIntegrationHandler.cs
@@ -20,4 +20,11 @@ public interface ITextureIntegrationHandler
         IGmlManager gmlManager,
         IValidator<UrlServiceDto> validator,
         UrlServiceDto urlDto);
+
+    static abstract Task<IResult> GetSlimUrl(IGmlManager gmlManager);
+
+    static abstract Task<IResult> SetSlimUrl(
+        IGmlManager gmlManager,
+        IValidator<UrlServiceDto> validator,
+        UrlServiceDto urlDto);
 }

--- a/src/Gml.Web.Api/src/Gml.Web.Api/Core/Handlers/TextureIntegrationHandler.cs
+++ b/src/Gml.Web.Api/src/Gml.Web.Api/Core/Handlers/TextureIntegrationHandler.cs
@@ -56,6 +56,20 @@ public class TextureIntegrationHandler : ITextureIntegrationHandler
         }
     }
 
+    public static async Task<IResult> GetSlimUrl(IGmlManager gmlManager)
+    {
+        try
+        {
+            var url = await gmlManager.Integrations.GetSlimServiceAsync();
+
+            return Results.Ok(ResponseMessage.Create(new UrlServiceDto(url), "Успешно", HttpStatusCode.OK));
+        }
+        catch (Exception exception)
+        {
+            return Results.BadRequest(ResponseMessage.Create(exception.Message, HttpStatusCode.BadRequest));
+        }
+    }
+
     public static async Task<IResult> SetCloakUrl(
         IGmlManager gmlManager,
         IValidator<UrlServiceDto> validator,
@@ -70,6 +84,22 @@ public class TextureIntegrationHandler : ITextureIntegrationHandler
         await gmlManager.Integrations.SetCloakServiceAsync(urlDto.Url);
 
         return Results.Ok(ResponseMessage.Create("Сервис плащей успешно обновлен", HttpStatusCode.OK));
+    }
+
+    public static async Task<IResult> SetSlimUrl(
+        IGmlManager gmlManager,
+        IValidator<UrlServiceDto> validator,
+        UrlServiceDto urlDto)
+    {
+        var result = await validator.ValidateAsync(urlDto);
+
+        if (!result.IsValid)
+            return Results.BadRequest(ResponseMessage.Create(result.Errors, "Ошибка валидации",
+                HttpStatusCode.BadRequest));
+
+        await gmlManager.Integrations.SetSlimServiceAsync(urlDto.Url);
+
+        return Results.Ok(ResponseMessage.Create("Сервис slim успешно обновлен", HttpStatusCode.OK));
     }
 
     public static async Task<IResult> UpdateUserSkin(

--- a/src/Gml.Web.Api/tests/Gml.WebApi.Tests/Tests.cs
+++ b/src/Gml.Web.Api/tests/Gml.WebApi.Tests/Tests.cs
@@ -948,4 +948,40 @@ public class Tests
             Assert.That(response.IsSuccessStatusCode, Is.True);
         });
     }
+
+    [Test]
+    [Order(58)]
+    public async Task UpdateSlimUrl()
+    {
+        var httpContent = TestHelper.CreateJsonObject(new UrlServiceDto(_newTextureUrl));
+
+        var response = await _httpClient.PutAsync("/api/v1/integrations/texture/slim", httpContent);
+        var content = await response.Content.ReadAsStringAsync();
+
+        var model = JsonConvert.DeserializeObject<ResponseMessage<UrlServiceDto>>(content);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(model, Is.Not.Null);
+            Assert.IsTrue(response.IsSuccessStatusCode);
+        });
+    }
+
+    [Test]
+    [Order(59)]
+    public async Task GetSlimUrl()
+    {
+        var response = await _httpClient.GetAsync("/api/v1/integrations/texture/slim");
+        var content = await response.Content.ReadAsStringAsync();
+
+        var model = JsonConvert.DeserializeObject<ResponseMessage<UrlServiceDto>>(content);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model?.Data, Is.Not.Null);
+            Assert.That(model?.Data?.Url, Is.EqualTo(_newTextureUrl));
+            Assert.That(response.IsSuccessStatusCode, Is.True);
+        });
+    }
 }

--- a/src/Gml.Web.Client/src/features/connect-textures-form/lib/static.ts
+++ b/src/Gml.Web.Client/src/features/connect-textures-form/lib/static.ts
@@ -9,6 +9,10 @@ export const ConnectTexturesSchema = z.object({
     .string()
     .min(1, { message: 'Вы не заполнили поле' })
     .transform((v) => v.trim()),
+  url_slim: z
+    .string()
+    .optional()
+    .transform((v) => v?.trim() ?? ''),
 });
 
 export type ConnectTexturesFormSchemaType = z.infer<typeof ConnectTexturesSchema>;

--- a/src/Gml.Web.Client/src/features/connect-textures-form/ui/ConnectTexturesForm.tsx
+++ b/src/Gml.Web.Client/src/features/connect-textures-form/ui/ConnectTexturesForm.tsx
@@ -28,12 +28,14 @@ import { TextureServiceBaseEntity } from '@/shared/api/contracts';
 interface ConnectTexturesFormProps extends React.HTMLAttributes<HTMLDivElement> {
   skins?: TextureServiceBaseEntity;
   cloaks?: TextureServiceBaseEntity;
+  slim?: TextureServiceBaseEntity;
   onOpenChange: (open: boolean) => void;
 }
 
 export function ConnectTexturesForm({
   skins,
   cloaks,
+  slim,
   onOpenChange,
   ...props
 }: ConnectTexturesFormProps) {
@@ -43,6 +45,7 @@ export function ConnectTexturesForm({
     values: {
       url_skins: skins?.url || '',
       url_cloaks: cloaks?.url || '',
+      url_slim: slim?.url || '',
     },
     resolver: zodResolver(ConnectTexturesSchema),
   });
@@ -59,6 +62,13 @@ export function ConnectTexturesForm({
       await mutateAsync({
         type: TexturesServiceType.TEXTURES_SERVICE_CLOAKS,
         url: data.url_cloaks,
+      });
+    }
+
+    if (form.getFieldState('url_slim').isDirty && data.url_slim) {
+      await mutateAsync({
+        type: TexturesServiceType.TEXTURES_SERVICE_SLIM,
+        url: data.url_slim,
       });
     }
 
@@ -92,9 +102,11 @@ export function ConnectTexturesForm({
     },
   ];
 
-  const handleButtonClick = (skinsUrl: string, cloaksUrl: string) => {
+  const handleButtonClick = (skinsUrl: string, cloaksUrl: string, slimUrl?: string) => {
     form.setValue('url_skins', skinsUrl, { shouldDirty: true });
     form.setValue('url_cloaks', cloaksUrl, { shouldDirty: true });
+    if (slimUrl)
+      form.setValue('url_slim', slimUrl, { shouldDirty: true });
   };
 
   return (
@@ -191,6 +203,24 @@ export function ConnectTexturesForm({
                         </FormControl>
                         {form.formState.errors.url_cloaks && (
                           <FormMessage>{form.formState.errors.url_cloaks.message}</FormMessage>
+                        )}
+                      </FormItem>
+                    )}
+                  />
+
+                  <Controller
+                    control={form.control}
+                    name="url_slim"
+                    render={({ field }) => (
+                      <FormItem className="flex-1">
+                        <FormLabel>URL сервиса slim</FormLabel>
+                        <FormControl>
+                          <div className="relative">
+                            <Input placeholder="Введите URL проверки slim" {...field} />
+                          </div>
+                        </FormControl>
+                        {form.formState.errors.url_slim && (
+                          <FormMessage>{form.formState.errors.url_slim.message}</FormMessage>
                         )}
                       </FormItem>
                     )}

--- a/src/Gml.Web.Client/src/shared/enums/textures.ts
+++ b/src/Gml.Web.Client/src/shared/enums/textures.ts
@@ -1,4 +1,5 @@
 export enum TexturesServiceType {
   TEXTURES_SERVICE_SKINS = 'skins',
   TEXTURES_SERVICE_CLOAKS = 'cloaks',
+  TEXTURES_SERVICE_SLIM = 'slim',
 }

--- a/src/Gml.Web.Client/src/shared/hooks/useIntegrations.ts
+++ b/src/Gml.Web.Client/src/shared/hooks/useIntegrations.ts
@@ -228,6 +228,10 @@ export const useEditConnectTextures = () => {
         await queryClient.invalidateQueries({
           queryKey: integrationsKeys.texturesEditing(TexturesServiceType.TEXTURES_SERVICE_CLOAKS),
         });
+      if (variables.type === TexturesServiceType.TEXTURES_SERVICE_SLIM)
+        await queryClient.invalidateQueries({
+          queryKey: integrationsKeys.texturesEditing(TexturesServiceType.TEXTURES_SERVICE_SLIM),
+        });
       toast.success('Успешно', {
         description: data.message,
       });

--- a/src/Gml.Web.Client/src/widgets/connect-textures-dialog/ui/ConnectTexturesDialog.tsx
+++ b/src/Gml.Web.Client/src/widgets/connect-textures-dialog/ui/ConnectTexturesDialog.tsx
@@ -26,6 +26,9 @@ export function ConnectTexturesDialog() {
   const { data: textures_cloaks, isLoading: isLoadingCloaks } = useConnectTextures(
     TexturesServiceType.TEXTURES_SERVICE_CLOAKS,
   );
+  const { data: textures_slim, isLoading: isLoadingSlim } = useConnectTextures(
+    TexturesServiceType.TEXTURES_SERVICE_SLIM,
+  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -34,7 +37,7 @@ export function ConnectTexturesDialog() {
           size="sm"
           variant="outline"
           className="w-fit"
-          disabled={isLoadingSkins || isLoadingCloaks}
+          disabled={isLoadingSkins || isLoadingCloaks || isLoadingSlim}
         >
           <WallpaperIcon className="mr-2" size={16} />
           Настроить
@@ -56,6 +59,7 @@ export function ConnectTexturesDialog() {
           <ConnectTexturesForm
             skins={textures_skins}
             cloaks={textures_cloaks}
+            slim={textures_slim}
             onOpenChange={onOpenChange}
           />
         </div>


### PR DESCRIPTION
## Summary
- add slim texture service endpoint in frontend
- support slim endpoint in backend services and player model
- test slim texture endpoint

## Testing
- `dotnet test src/Gml.Web.Api/tests/Gml.WebApi.Tests/Gml.WebApi.Tests.csproj` *(fails: DatabaseContext not found)*
- `npx playwright test` *(fails: missing system dependencies for browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc8c8ca4832f91942db6a5b9abb8